### PR TITLE
Fix missing byobu doc files in devcontainer images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 # Layer 1: Base system dependencies and utilities (most stable)
-RUN apt-get update && \
+# Allow byobu doc files (base image excludes /usr/share/doc/*)
+RUN printf 'path-include /usr/share/doc/byobu/*\n' > /etc/dpkg/dpkg.cfg.d/byobu && \
+    apt-get update && \
     apt-get install -y \
         curl wget unzip \
         jq yq \

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -3,7 +3,9 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 # Layer 1: Base system dependencies and utilities (most stable)
-RUN apt-get update && \
+# Allow byobu doc files (base image excludes /usr/share/doc/*)
+RUN printf 'path-include /usr/share/doc/byobu/*\n' > /etc/dpkg/dpkg.cfg.d/byobu && \
+    apt-get update && \
     apt-get install -y \
         curl wget unzip \
         jq yq \


### PR DESCRIPTION
## Summary
- The base devcontainer image excludes `/usr/share/doc/*` via dpkg config, stripping byobu's help files
- Added a targeted `path-include` exception for byobu docs in both `Dockerfile` and `Dockerfile.lite`

## Test plan
- [ ] Build lite image and verify `ls /usr/share/doc/byobu/` contains help files
- [ ] Build full image and verify the same
- [ ] Confirm byobu help (F1) works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)