### PR TITLE
Remove Go and Rust from lite image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Docker devcontainer images pre-loaded with AI coding agents (Claude Code, OpenAI
 - **`Dockerfile`** (full): Dev tools + cloud CLIs (AWS, Azure, GCP) + GitHub CLI
 - **`Dockerfile.lite`**: Dev tools + GitHub CLI only, no cloud CLIs
 
-Both share the same base (`mcr.microsoft.com/devcontainers/base:ubuntu`) and toolchain layers (Go, Rust, Node.js LTS, Python 3 + uv). They diverge at the cloud CLI layer. Container user is `vscode`.
+Both share the same base (`mcr.microsoft.com/devcontainers/base:ubuntu`). The full image includes Go, Rust, Node.js LTS, Python 3 + uv. The lite image includes Node.js LTS, Python 3 + uv (no Go/Rust). They also diverge at the cloud CLI layer. Container user is `vscode`.
 
 ## Build Commands
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -21,17 +21,7 @@ RUN printf 'path-include /usr/share/doc/byobu/*\n' > /etc/dpkg/dpkg.cfg.d/byobu 
 # Layer 2: Install uv (modern Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
-# Layer 3: Install Go
-RUN GO_VERSION="1.26.0" && \
-    ARCH=$(dpkg --print-architecture) && \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -xzC /usr/local && \
-    echo 'export PATH=/usr/local/go/bin:$PATH' >> /etc/profile
-
-# Layer 4: Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    echo 'source ~/.cargo/env' >> /etc/profile
-
-# Layer 5: Install Node.js LTS
+# Layer 3: Install Node.js LTS
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs
 
@@ -63,7 +53,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN sudo npm install -g @openai/codex
 
 # Layer 9: Final environment setup
-ENV PATH="/home/vscode/.local/bin:/usr/local/go/bin:/home/vscode/.cargo/bin:${PATH}"
+ENV PATH="/home/vscode/.local/bin:${PATH}"
 ENV SHELL=/usr/bin/zsh
 ENV DISABLE_AUTOUPDATER=true
 


### PR DESCRIPTION
## Summary
- Drop Go (~277 MB) and Rust (~1.32 GB) toolchains from `Dockerfile.lite`
- Clean up PATH env var to remove stale Go/Rust entries
- Update CLAUDE.md to document the toolchain divergence between full and lite images

Reduces lite image from ~4.2 GB to ~2.6 GB on disk.

## Test plan
- [ ] Build lite image and verify Node.js, Python, uv, Claude Code, Codex, gh all work
- [ ] Confirm Go and Rust are intentionally absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)