### PR TITLE
Add claudy alias for skip-permissions mode

### DIFF
--- a/config/.zshrc
+++ b/config/.zshrc
@@ -106,6 +106,7 @@ source $ZSH/oh-my-zsh.sh
 
 alias gs='git status'
 alias gbh="git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'"
+alias claudy='claude --dangerously-skip-permissions'
 
 # Fancy function that is effectively an alias for `gh pr merge`
 ghprm() {


### PR DESCRIPTION
## Summary
- Add `claudy` shell alias for `claude --dangerously-skip-permissions`

## Test plan
- [ ] Build image and verify `alias claudy` is set in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)