### PR TITLE
Add cache-busting to daily builds and print tool versions

### DIFF
--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -50,6 +50,8 @@ jobs:
           file: Dockerfile.lite
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
           cache-from: type=gha,scope=lite-${{ steps.platform.outputs.slug }}
           cache-to: type=gha,scope=lite-${{ steps.platform.outputs.slug }},mode=max
 
@@ -138,6 +140,7 @@ jobs:
             # Test Claude Code
             if command -v claude >/dev/null 2>&1; then
               echo '✅ Claude Code installed'
+              claude --version
             else
               echo '❌ Claude Code missing' && exit 1
             fi
@@ -145,6 +148,7 @@ jobs:
             # Test OpenAI Codex
             if command -v codex >/dev/null 2>&1; then
               echo '✅ OpenAI Codex installed'
+              codex --version
             else
               echo '❌ OpenAI Codex missing' && exit 1
             fi
@@ -152,6 +156,7 @@ jobs:
             # Test GitHub CLI
             if command -v gh >/dev/null 2>&1; then
               echo '✅ GitHub CLI installed'
+              gh --version
             else
               echo '❌ GitHub CLI missing' && exit 1
             fi

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -50,6 +50,8 @@ jobs:
           file: Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
           cache-from: type=gha,scope=${{ steps.platform.outputs.slug }}
           cache-to: type=gha,scope=${{ steps.platform.outputs.slug }},mode=max
 
@@ -138,6 +140,7 @@ jobs:
             # Test Claude Code
             if command -v claude >/dev/null 2>&1; then
               echo '✅ Claude Code installed'
+              claude --version
             else
               echo '❌ Claude Code missing' && exit 1
             fi
@@ -145,6 +148,7 @@ jobs:
             # Test OpenAI Codex
             if command -v codex >/dev/null 2>&1; then
               echo '✅ OpenAI Codex installed'
+              codex --version
             else
               echo '❌ OpenAI Codex missing' && exit 1
             fi
@@ -152,6 +156,7 @@ jobs:
             # Test GitHub CLI
             if command -v gh >/dev/null 2>&1; then
               echo '✅ GitHub CLI installed'
+              gh --version
             else
               echo '❌ GitHub CLI missing' && exit 1
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
 # Layer 2: Install uv (modern Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
+# Cache-bust from here down so daily builds pick up new versions of
+# everything installed via script (Homebrew, Go, Rust, Node, CLIs, AI tools)
+ARG CACHEBUST
+
 # Layer 3: Install Homebrew
 USER vscode
 RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -34,6 +34,10 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
 # Layer 2: Install uv (modern Python package manager)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
+# Cache-bust from here down so daily builds pick up new versions of
+# everything installed via script (Homebrew, Node, GitHub CLI, AI tools)
+ARG CACHEBUST
+
 # Layer 3: Install Homebrew
 USER vscode
 RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
## Summary
- Add `ARG CACHEBUST` to both Dockerfiles right after the stable base layers (system packages + uv), so all script-based installs (Homebrew, Go, Rust, Node, CLIs, AI tools) rebuild on every daily run
- Pass `CACHEBUST=${{ github.run_id }}` in both daily build workflows to ensure a unique value each run
- Print `claude --version`, `codex --version`, and `gh --version` in the test-image step for visibility

## Test plan
- [x] PR builds pass (validates Dockerfile syntax and tool presence)
- [x] Trigger a manual daily build and confirm previously-cached layers now rebuild
- [x] Verify version output appears in test-image job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)