### PR TITLE
Add common network diagnostic tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,15 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
         build-essential \
         python3 python3-pip \
         byobu \
-        man-db && \
+        man-db \
+        iputils-ping \
+        dnsutils \
+        traceroute \
+        net-tools \
+        netcat-openbsd \
+        tcpdump \
+        telnet \
+        nmap && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -26,7 +26,15 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
         build-essential \
         python3 python3-pip \
         byobu \
-        man-db && \
+        man-db \
+        iputils-ping \
+        dnsutils \
+        traceroute \
+        net-tools \
+        netcat-openbsd \
+        tcpdump \
+        telnet \
+        nmap && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add network diagnostic packages to Layer 1 in both `Dockerfile` and `Dockerfile.lite`
- Packages: `iputils-ping`, `dnsutils`, `traceroute`, `net-tools`, `netcat-openbsd`, `tcpdump`, `telnet`, `nmap`

## Test plan
- [ ] Build full image: `docker build -t devcontainer:local -f Dockerfile .`
- [ ] Build lite image: `docker build -t devcontainer-lite:local -f Dockerfile.lite .`
- [ ] Verify tools are available: `ping`, `nslookup`, `dig`, `traceroute`, `ifconfig`, `netstat`, `nc`, `tcpdump`, `telnet`, `nmap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added networking and diagnostic utilities to Docker images, including ping, DNS tools, traceroute, network utilities, netcat, tcpdump, telnet, and nmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->