### PR TITLE
Add lite-tmux image variant, remove tmux from plain lite

### DIFF
--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Delete old daily images
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with:
           package-name: devcontainer-lite-tmux
           package-type: container

--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -1,0 +1,181 @@
+name: Daily Docker Image Build (Lite+Tmux)
+
+on:
+  schedule:
+    # Run daily at 3 AM PST (11:00 UTC)
+    - cron: '0 11 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-lite-tmux
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract platform slug
+        id: platform
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.lite.tmux
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
+          cache-from: type=gha,scope=lite-tmux-${{ steps.platform.outputs.slug }}
+          cache-to: type=gha,scope=lite-tmux-${{ steps.platform.outputs.slug }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-lite-tmux-${{ steps.platform.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-lite-tmux-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=daily-{{date 'YYYY-MM-DD'}},enable={{is_default_branch}}
+            type=raw,value={{date 'YYYY-MM-DD'}},enable={{is_default_branch}}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  test-image:
+    needs: merge
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test image functionality
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          echo "Testing daily build image: $IMAGE"
+
+          docker run --rm "$IMAGE" /bin/bash -c "
+            echo 'Testing installations...'
+
+            # Test Claude Code
+            if command -v claude >/dev/null 2>&1; then
+              echo '✅ Claude Code installed'
+              claude --version
+            else
+              echo '❌ Claude Code missing' && exit 1
+            fi
+
+            # Test OpenAI Codex
+            if command -v codex >/dev/null 2>&1; then
+              echo '✅ OpenAI Codex installed'
+              codex --version
+            else
+              echo '❌ OpenAI Codex missing' && exit 1
+            fi
+
+            # Test GitHub CLI
+            if command -v gh >/dev/null 2>&1; then
+              echo '✅ GitHub CLI installed'
+              gh --version
+            else
+              echo '❌ GitHub CLI missing' && exit 1
+            fi
+
+            echo 'All core tools are properly installed!'
+          "
+
+  cleanup-old-images:
+    needs: [merge, test-image]
+    runs-on: ubuntu-latest
+    if: success()
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old daily images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: devcontainer-lite-tmux
+          package-type: container
+          min-versions-to-keep: 7
+          delete-only-untagged-versions: false

--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Delete old daily images
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with:
           package-name: devcontainer-lite
           package-type: container

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Delete old daily images
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with:
           package-name: devcontainer
           package-type: container

--- a/.github/workflows/docker-pr-build-lite-tmux.yml
+++ b/.github/workflows/docker-pr-build-lite-tmux.yml
@@ -1,0 +1,74 @@
+name: Docker PR Build (Lite+Tmux)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-lite-tmux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            dockerfile:
+              - 'Dockerfile.lite.tmux'
+              - 'scripts/entrypoint.sh'
+              - '.github/workflows/daily-docker-build-lite-tmux.yml'
+              - '.github/workflows/docker-pr-build-lite-tmux.yml'
+
+      - name: Checkout repository
+        if: steps.changes.outputs.dockerfile == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.dockerfile == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        if: steps.changes.outputs.dockerfile == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.lite.tmux
+          load: true
+          tags: devcontainer-lite-tmux:pr-test
+          cache-from: type=gha,scope=lite-tmux-pr
+          cache-to: type=gha,scope=lite-tmux-pr,mode=max
+
+      - name: Test image functionality
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: |
+          docker run --rm devcontainer-lite-tmux:pr-test /bin/bash -c "
+            echo 'Testing installations...'
+
+            if command -v claude >/dev/null 2>&1; then
+              echo '✅ Claude Code installed'
+            else
+              echo '❌ Claude Code missing' && exit 1
+            fi
+
+            if command -v codex >/dev/null 2>&1; then
+              echo '✅ OpenAI Codex installed'
+            else
+              echo '❌ OpenAI Codex missing' && exit 1
+            fi
+
+            if command -v gh >/dev/null 2>&1; then
+              echo '✅ GitHub CLI installed'
+            else
+              echo '❌ GitHub CLI missing' && exit 1
+            fi
+
+            echo 'All core tools are properly installed!'
+          "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,11 @@ Docker devcontainer images pre-loaded with AI coding agents (Claude Code, OpenAI
 
 ## Image Variants
 
-- **`Dockerfile`** (full): Dev tools + cloud CLIs (AWS, Azure, GCP) + GitHub CLI
-- **`Dockerfile.lite`**: Dev tools + GitHub CLI only, no cloud CLIs
+- **`Dockerfile`** (full): Dev tools + cloud CLIs (AWS, Azure, GCP) + GitHub CLI + byobu/tmux
+- **`Dockerfile.lite`**: Dev tools + GitHub CLI only, no cloud CLIs, no byobu/tmux
+- **`Dockerfile.lite.tmux`**: Same as lite but with byobu/tmux installed and auto-launched on login
 
-Both share the same base (`mcr.microsoft.com/devcontainers/base:ubuntu`). The full image includes Go, Rust, Node.js LTS, Python 3 + uv. The lite image includes Node.js LTS, Python 3 + uv (no Go/Rust). They also diverge at the cloud CLI layer. Container user is `vscode`.
+Both share the same base (`mcr.microsoft.com/devcontainers/base:ubuntu`). The full image includes Go, Rust, Node.js LTS, Python 3 + uv. The lite images include Node.js LTS, Python 3 + uv (no Go/Rust). They also diverge at the cloud CLI layer. Container user is `vscode`. The plain lite image is designed for use inside environments that already provide a terminal multiplexer (e.g. tmux on a remote VPS host).
 
 ## Base Image Quirks
 
@@ -29,20 +30,25 @@ docker build -t devcontainer:local -f Dockerfile .
 # Build lite image locally
 docker build -t devcontainer-lite:local -f Dockerfile.lite .
 
+# Build lite+tmux image locally
+docker build -t devcontainer-lite-tmux:local -f Dockerfile.lite.tmux .
+
 # Test that core tools are installed
 docker run --rm devcontainer:local /bin/bash -c "command -v claude && command -v codex && command -v gh"
 ```
 
 ## CI/CD
 
-Four GitHub Actions workflows in `.github/workflows/`:
+Six GitHub Actions workflows in `.github/workflows/`:
 
 | Workflow | Trigger | Image |
 |---|---|---|
 | `daily-docker-build.yml` | Daily 3AM PST + manual | full (`ghcr.io/<repo>`) |
 | `daily-docker-build-lite.yml` | Daily 3AM PST + manual | lite (`ghcr.io/<repo>-lite`) |
+| `daily-docker-build-lite-tmux.yml` | Daily 3AM PST + manual | lite+tmux (`ghcr.io/<repo>-lite-tmux`) |
 | `docker-pr-build.yml` | PR touching `Dockerfile` | full (build+test only) |
 | `docker-pr-build-lite.yml` | PR touching `Dockerfile.lite` | lite (build+test only) |
+| `docker-pr-build-lite-tmux.yml` | PR touching `Dockerfile.lite.tmux` | lite+tmux (build+test only) |
 
 Daily builds: multi-arch (amd64/arm64) with digest-based merge, tagged `latest`, `daily-YYYY-MM-DD`, `YYYY-MM-DD`. Keeps last 7 versions. PR builds: single-arch validation with smoke tests.
 
@@ -53,3 +59,5 @@ Layers are ordered by stability (most stable first) to maximize cache hits.
 **Full image**: System packages → uv → Go → Rust → Node.js LTS → Cloud CLIs + GitHub CLI → Shell config → AI tools → ENV/PATH
 
 **Lite image**: System packages → uv → Node.js LTS → GitHub CLI → Shell config → AI tools → ENV/PATH
+
+**Lite+Tmux image**: Same as lite but with byobu (tmux) in the system packages layer and auto-launch in shell config

--- a/Dockerfile.lite.tmux
+++ b/Dockerfile.lite.tmux
@@ -12,8 +12,11 @@ RUN if getent group 20 > /dev/null 2>&1; then \
     chown -R 501:20 /home/vscode
 
 # Layer 1: Base system dependencies and utilities (most stable)
+# Re-include byobu docs/man (base image minimized via /etc/dpkg/dpkg.cfg.d/excludes)
+# Filename zz- ensures this is processed AFTER excludes so includes win
 # Remove man stub diversion so man-db can install the real man binary
-RUN rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && \
+RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man1/byobu*\n' > /etc/dpkg/dpkg.cfg.d/zz-byobu && \
+    rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && \
     apt-get update && \
     apt-get install -y \
         curl wget unzip \
@@ -22,6 +25,7 @@ RUN rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && 
         make \
         build-essential \
         python3 python3-pip \
+        byobu \
         man-db \
         iputils-ping \
         dnsutils \
@@ -69,7 +73,10 @@ USER vscode
 COPY --chown=vscode:vscode config/.zshrc /home/vscode/.zshrc
 COPY --chown=vscode:vscode config/.p10k.zsh /home/vscode/.p10k.zsh
 RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
-    ${ZSH_CUSTOM:-/home/vscode/.oh-my-zsh/custom}/themes/powerlevel10k
+    ${ZSH_CUSTOM:-/home/vscode/.oh-my-zsh/custom}/themes/powerlevel10k && \
+    # Enable byobu auto-launch on login
+    printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.zprofile && \
+    printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.profile
 
 # Layer 7: AI CLI tools (most volatile - frequent releases)
 # Install Claude Code


### PR DESCRIPTION
## Summary
- Split `Dockerfile.lite` into two variants: plain lite (no byobu/tmux) and `Dockerfile.lite.tmux` (with byobu/tmux auto-launched on login)
- Plain lite image is designed for environments that already provide a terminal multiplexer (e.g. running inside a cage on a remote VPS with tmux on the host)
- Added daily build and PR build workflows for the new `lite-tmux` variant (`ghcr.io/<repo>-lite-tmux`)
- Updated `CLAUDE.md` to document all three image variants and six workflows

## Test plan
- [ ] Verify `Dockerfile.lite` builds without byobu/tmux
- [ ] Verify `Dockerfile.lite.tmux` builds with byobu/tmux and auto-launch
- [ ] Confirm PR workflows trigger correctly for changes to each Dockerfile variant
- [ ] Confirm daily build workflows produce correct image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lite+Tmux image variant that includes a terminal multiplexer (auto-launch on login).
  * Multi-arch daily builds now produce amd64/arm64 images and publish combined manifests for broader platform availability.

* **Documentation**
  * Updated image descriptions and build matrix to document the new Lite+Tmux variant and clarify the plain lite image’s scope.

* **Chores**
  * Added CI workflows for daily builds and PR-based image tests; updated cleanup action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->