### PR TITLE
Fix entrypoint overwriting newer Claude with older image version

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,6 +25,16 @@ sync_claude() {
 
     [ "$image_version" = "$volume_version" ] && return 0
 
+    # Don't overwrite a newer version already in the volume (e.g. from `claude update`)
+    if [ -n "$volume_version" ]; then
+        local higher
+        higher=$(printf '%s\n%s\n' "$image_version" "$volume_version" | sort -V | tail -n1)
+        if [ "$higher" = "$volume_version" ]; then
+            echo "[entrypoint] Volume has newer Claude ($volume_version), skipping image version ($image_version)"
+            return 0
+        fi
+    fi
+
     echo "[entrypoint] Updating Claude: ${volume_version:-not installed} -> $image_version"
     mkdir -p "$LIVE_SHARE/versions" "$(dirname "$LIVE_BIN")"
     cp -a "$STAGED_DIR/versions/$image_version" "$LIVE_SHARE/versions/$image_version"


### PR DESCRIPTION
## Summary
- The entrypoint sync logic only checked for version inequality, so when the volume had a newer Claude (e.g. installed via `claude update` inside the container), the entrypoint would downgrade it to the older image version
- Added `sort -V` version comparison to skip the copy when the volume already has a newer version

## Test plan
- [ ] Build image, start container with a volume, run `claude update` to get a newer version, restart container — verify entrypoint skips the downgrade and logs `Volume has newer Claude`
- [ ] Start container with no existing volume — verify entrypoint still installs Claude from the image normally
- [ ] Start container with an older volume version — verify entrypoint upgrades as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved startup version comparison to prevent component downgrades. The system now properly identifies when a persisted version matches or exceeds the staged version, skipping unnecessary updates while preserving the upgrade path when a newer version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->