### PR TITLE
Add runtime UID/GID remap for non-macOS hosts

### DIFF
--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -164,6 +164,22 @@ jobs:
             echo 'All core tools are properly installed!'
           "
 
+      - name: Test runtime UID/GID remap
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '
+
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -164,6 +164,22 @@ jobs:
             echo 'All core tools are properly installed!'
           "
 
+      - name: Test runtime UID/GID remap
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '
+
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -164,6 +164,22 @@ jobs:
             echo 'All core tools are properly installed!'
           "
 
+      - name: Test runtime UID/GID remap
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '
+
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-pr-build-lite-tmux.yml
+++ b/.github/workflows/docker-pr-build-lite-tmux.yml
@@ -31,6 +31,10 @@ jobs:
         if: steps.changes.outputs.dockerfile == 'true'
         uses: actions/checkout@v4
 
+      - name: Test entrypoint gating logic
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: bash scripts/test_entrypoint.sh
+
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
         uses: docker/setup-buildx-action@v3
@@ -72,3 +76,19 @@ jobs:
 
             echo 'All core tools are properly installed!'
           "
+
+      - name: Test runtime UID/GID remap
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: |
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 devcontainer-lite-tmux:pr-test /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '

--- a/.github/workflows/docker-pr-build-lite.yml
+++ b/.github/workflows/docker-pr-build-lite.yml
@@ -31,6 +31,10 @@ jobs:
         if: steps.changes.outputs.dockerfile == 'true'
         uses: actions/checkout@v4
 
+      - name: Test entrypoint gating logic
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: bash scripts/test_entrypoint.sh
+
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
         uses: docker/setup-buildx-action@v3
@@ -72,3 +76,19 @@ jobs:
 
             echo 'All core tools are properly installed!'
           "
+
+      - name: Test runtime UID/GID remap
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: |
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 devcontainer-lite:pr-test /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -31,6 +31,10 @@ jobs:
         if: steps.changes.outputs.dockerfile == 'true'
         uses: actions/checkout@v4
 
+      - name: Test entrypoint gating logic
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: bash scripts/test_entrypoint.sh
+
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
         uses: docker/setup-buildx-action@v3
@@ -72,3 +76,19 @@ jobs:
 
             echo 'All core tools are properly installed!'
           "
+
+      - name: Test runtime UID/GID remap
+        if: steps.changes.outputs.dockerfile == 'true'
+        run: |
+          docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 devcontainer:pr-test /bin/bash -c '
+            set -e
+            echo "Inside container: uid=$(id -u) gid=$(id -g)"
+            [ "$(id -u)" = "4242" ] || { echo "FAIL: UID mismatch (got $(id -u), want 4242)"; exit 1; }
+            [ "$(id -g)" = "4243" ] || { echo "FAIL: GID mismatch (got $(id -g), want 4243)"; exit 1; }
+            touch /home/vscode/probe
+            probe_owner=$(stat -c %u:%g /home/vscode/probe)
+            [ "$probe_owner" = "4242:4243" ] || { echo "FAIL: probe owner $probe_owner != 4242:4243"; exit 1; }
+            zshrc_owner=$(stat -c %u:%g /home/vscode/.zshrc)
+            [ "$zshrc_owner" = "4242:4243" ] || { echo "FAIL: .zshrc owner $zshrc_owner != 4242:4243"; exit 1; }
+            echo "Remap OK"
+          '

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,17 +1,53 @@
 #!/bin/bash
 #
-# Sync Claude Code from the image layer into the persistent volume.
+# Container entrypoint. Two responsibilities:
 #
-# Problem: Claude installs to /home/vscode/.local/, but a named volume
-# mounted at /home/vscode shadows the image layer. This script stages
-# the image's Claude at /opt/claude-image/ (build time) and copies it
-# into the volume on container start when the image has a newer version.
+# 1. Remap the vscode user's UID/GID at runtime when HOST_UID/HOST_GID are
+#    set, so bind mounts from non-macOS hosts (typically 1000:1000 on Linux)
+#    line up with the in-container user. macOS hosts leave the env vars
+#    unset and the image's baked-in 501:20 is used as-is.
 #
+# 2. Sync Claude Code from the image layer into the persistent volume.
+#    See sync_claude() for details.
 
 STAGED_DIR="/opt/claude-image"
 LIVE_SHARE="/home/vscode/.local/share/claude"
 LIVE_BIN="/home/vscode/.local/bin/claude"
 
+remap_needed() {
+    [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ] || return 1
+    [ "$(id -u vscode)" = "$HOST_UID" ] && [ "$(id -g vscode)" = "$HOST_GID" ] && return 1
+    return 0
+}
+
+remap_user() {
+    local current_uid current_gid squatter
+    current_uid=$(id -u vscode)
+    current_gid=$(id -g vscode)
+
+    echo "[entrypoint] Remapping vscode ${current_uid}:${current_gid} -> ${HOST_UID}:${HOST_GID}"
+
+    # If another group already holds the target GID, move it out of the way
+    # (same dance the Dockerfile does at build time for GID 20 / dialout).
+    squatter=$(getent group "$HOST_GID" | cut -d: -f1)
+    if [ -n "$squatter" ] && [ "$squatter" != "vscode" ]; then
+        sudo groupmod -g 9998 "$squatter" || return 1
+    fi
+
+    sudo groupmod -g "$HOST_GID" vscode || return 1
+    sudo usermod  -u "$HOST_UID" vscode || return 1
+
+    # Chown anything under /home owned by the old UID/GID. Covers /home/vscode
+    # and /home/linuxbrew (full image only). Files with unrelated owners are
+    # left alone.
+    sudo find /home -uid "$current_uid" -exec chown -h "$HOST_UID" {} + || true
+    sudo find /home -gid "$current_gid" -exec chgrp -h "$HOST_GID" {} + || true
+}
+
+# Claude installs to /home/vscode/.local/, but a named volume mounted at
+# /home/vscode shadows the image layer. The Dockerfile stages Claude at
+# /opt/claude-image/ at build time; this copies it into the volume on
+# container start when the image has a newer version.
 sync_claude() {
     [ ! -f "$STAGED_DIR/version" ] && return 0
 
@@ -42,7 +78,21 @@ sync_claude() {
     echo "[entrypoint] Claude updated to $image_version"
 }
 
-# Never let sync failure prevent container startup
+# If a remap is needed, do it and then re-exec so the running process picks up
+# the new UID/GID. The sentinel prevents looping if the re-exec ever lands
+# back here without a successful remap.
+if [ "$ENTRYPOINT_REMAPPED" != "1" ] && remap_needed; then
+    if remap_user; then
+        # secure_path in sudoers would otherwise clobber the image's ENV PATH.
+        exec sudo \
+            --preserve-env=PATH,HOME,SHELL,TERM,HOST_UID,HOST_GID \
+            ENTRYPOINT_REMAPPED=1 \
+            -u vscode -- "$0" "$@"
+    else
+        echo "[entrypoint] WARNING: user remap failed, continuing with image defaults" >&2
+    fi
+fi
+
 sync_claude || echo "[entrypoint] WARNING: Claude sync failed, continuing." >&2
 
 exec "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,28 +20,41 @@ remap_needed() {
     return 0
 }
 
-remap_user() {
-    local current_uid current_gid squatter
+# Elevate to root, remap vscode, then drop back to vscode and re-exec the
+# entrypoint — all in a single sudo invocation. This matters because once
+# `usermod -u $HOST_UID vscode` rewrites /etc/passwd, the previously-vscode
+# UID (501) no longer exists in passwd, so the calling shell can't call
+# sudo again ("sudo: you do not exist in the passwd database").
+remap_and_reexec() {
+    local current_uid current_gid
     current_uid=$(id -u vscode)
     current_gid=$(id -g vscode)
 
     echo "[entrypoint] Remapping vscode ${current_uid}:${current_gid} -> ${HOST_UID}:${HOST_GID}"
 
-    # If another group already holds the target GID, move it out of the way
-    # (same dance the Dockerfile does at build time for GID 20 / dialout).
-    squatter=$(getent group "$HOST_GID" | cut -d: -f1)
-    if [ -n "$squatter" ] && [ "$squatter" != "vscode" ]; then
-        sudo groupmod -g 9998 "$squatter" || return 1
-    fi
+    export CURRENT_UID="$current_uid" CURRENT_GID="$current_gid" ENTRYPOINT_REMAPPED=1
 
-    sudo groupmod -g "$HOST_GID" vscode || return 1
-    sudo usermod  -u "$HOST_UID" vscode || return 1
-
-    # Chown anything under /home owned by the old UID/GID. Covers /home/vscode
-    # and /home/linuxbrew (full image only). Files with unrelated owners are
-    # left alone.
-    sudo find /home -uid "$current_uid" -exec chown -h "$HOST_UID" {} + || true
-    sudo find /home -gid "$current_gid" -exec chgrp -h "$HOST_GID" {} + || true
+    # secure_path in sudoers would otherwise clobber the image's ENV PATH.
+    exec sudo \
+        --preserve-env=PATH,HOME,SHELL,TERM,HOST_UID,HOST_GID,CURRENT_UID,CURRENT_GID,ENTRYPOINT_REMAPPED \
+        bash -c '
+            set -e
+            # If another group already holds the target GID, move it out of the
+            # way (same dance the Dockerfile does at build time for GID 20).
+            squatter=$(getent group "$HOST_GID" | cut -d: -f1)
+            if [ -n "$squatter" ] && [ "$squatter" != "vscode" ]; then
+                groupmod -g 9998 "$squatter"
+            fi
+            groupmod -g "$HOST_GID" vscode
+            usermod  -u "$HOST_UID" vscode
+            # Chown anything under /home owned by the old UID/GID. Covers
+            # /home/vscode and /home/linuxbrew (full image only).
+            find /home -uid "$CURRENT_UID" -exec chown -h "$HOST_UID" {} + || true
+            find /home -gid "$CURRENT_GID" -exec chgrp -h "$HOST_GID" {} + || true
+            # Drop privileges to the freshly-remapped vscode and re-enter the
+            # entrypoint; the ENTRYPOINT_REMAPPED sentinel skips this block.
+            exec runuser -u vscode -- "$@"
+        ' remap "$0" "$@"
 }
 
 # Claude installs to /home/vscode/.local/, but a named volume mounted at
@@ -78,19 +91,10 @@ sync_claude() {
     echo "[entrypoint] Claude updated to $image_version"
 }
 
-# If a remap is needed, do it and then re-exec so the running process picks up
-# the new UID/GID. The sentinel prevents looping if the re-exec ever lands
-# back here without a successful remap.
+# If a remap is needed, hand off to remap_and_reexec — it execs and never
+# returns. The sentinel prevents looping after the re-exec lands back here.
 if [ "$ENTRYPOINT_REMAPPED" != "1" ] && remap_needed; then
-    if remap_user; then
-        # secure_path in sudoers would otherwise clobber the image's ENV PATH.
-        exec sudo \
-            --preserve-env=PATH,HOME,SHELL,TERM,HOST_UID,HOST_GID \
-            ENTRYPOINT_REMAPPED=1 \
-            -u vscode -- "$0" "$@"
-    else
-        echo "[entrypoint] WARNING: user remap failed, continuing with image defaults" >&2
-    fi
+    remap_and_reexec "$@"
 fi
 
 sync_claude || echo "[entrypoint] WARNING: Claude sync failed, continuing." >&2

--- a/scripts/test_entrypoint.sh
+++ b/scripts/test_entrypoint.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Isolated test of the gating logic in scripts/entrypoint.sh.
+#
+# Verifies the conditions under which the entrypoint will (and won't)
+# attempt to remap the vscode user. Does NOT exercise the actual
+# usermod/groupmod/chown — those require root and a live container, and
+# are covered by the runtime test in the docker-pr-build* CI workflows.
+
+set -u
+
+# Duplicate of remap_needed from scripts/entrypoint.sh — keep in sync.
+remap_needed() {
+    [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ] || return 1
+    [ "$(id -u vscode)" = "$HOST_UID" ] && [ "$(id -g vscode)" = "$HOST_GID" ] && return 1
+    return 0
+}
+
+# Stub `id vscode` so we can simulate different in-container vscode states
+# without needing an actual vscode user on the test host.
+fake_uid=501
+fake_gid=20
+id() {
+    case "$1 ${2-}" in
+        "-u vscode") echo "$fake_uid" ;;
+        "-g vscode") echo "$fake_gid" ;;
+        *) command id "$@" ;;
+    esac
+}
+export -f id
+
+pass=0
+fail=0
+check() {
+    local label="$1" expect="$2" actual="$3"
+    if [ "$expect" = "$actual" ]; then
+        echo "PASS: $label"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $label (expected $expect, got $actual)"
+        fail=$((fail + 1))
+    fi
+}
+
+# macOS: no env vars, vscode at image default 501:20
+unset HOST_UID HOST_GID
+fake_uid=501; fake_gid=20
+remap_needed; check "macOS (no env vars) skips remap" 1 $?
+
+# Linux first start: env vars set, vscode at image default
+HOST_UID=1000 HOST_GID=1000
+fake_uid=501; fake_gid=20
+remap_needed; check "Linux first start triggers remap" 0 $?
+
+# Linux subsequent start: env vars set, vscode already remapped
+HOST_UID=1000 HOST_GID=1000
+fake_uid=1000; fake_gid=1000
+remap_needed; check "Linux subsequent start skips remap" 1 $?
+
+# Partial env (only HOST_UID): incomplete config, skip remap
+HOST_UID=1000; unset HOST_GID
+fake_uid=501; fake_gid=20
+remap_needed; check "Partial env (HOST_UID only) skips remap" 1 $?
+
+# UID matches but GID differs: still needs remap
+HOST_UID=501 HOST_GID=1000
+fake_uid=501; fake_gid=20
+remap_needed; check "UID matches but GID differs triggers remap" 0 $?
+
+# Sentinel ENTRYPOINT_REMAPPED=1: outer guard prevents re-entry even when remap_needed
+ENTRYPOINT_REMAPPED=1
+HOST_UID=1000 HOST_GID=1000
+fake_uid=501; fake_gid=20
+if [ "$ENTRYPOINT_REMAPPED" != "1" ] && remap_needed; then
+    entered=yes
+else
+    entered=no
+fi
+check "ENTRYPOINT_REMAPPED sentinel blocks re-entry" no "$entered"
+
+echo "---"
+echo "Passed: $pass  Failed: $fail"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Summary
- Entrypoint now remaps the vscode user in-place via `usermod`/`groupmod` + targeted `chown` when `HOST_UID`/`HOST_GID` are set, so Linux hosts (typically 1000:1000) don't hit ownership mismatches against the image's baked-in 501:20. macOS hosts leave the env vars unset and behavior is unchanged.
- Re-execs through `sudo --preserve-env=PATH,HOME,SHELL,TERM,...` so the running process picks up the new identity; an `ENTRYPOINT_REMAPPED=1` sentinel guards against re-entry.
- No Dockerfile changes — the MS base's passwordless sudo for vscode lets the entrypoint elevate just for the remap, keeping `USER vscode` as the default for `docker exec`.

## Rollout
Ship this image first. Until the caller (cage.sh) sends `HOST_UID`/`HOST_GID`, the new code stays dormant and the image behaves exactly as before.

## Test plan
- [x] Isolated bash unit test of `remap_needed` gating (6 cases, all pass locally)
- [x] YAML lints clean on all 6 modified workflows
- [ ] PR CI builds all 3 images and runs:
  - existing `command -v` smoke test (no-op path / macOS-default)
  - new `docker run -e HOST_UID=4242 -e HOST_GID=4243` test asserting `id -u`/`id -g` match and that both new files (`probe`) and existing ones (`.zshrc`) are chowned
- [ ] Daily builds get the same runtime remap test in the `test-image` job, against the merged ghcr image — catches future base-image regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime UID/GID remapping so container user/group IDs and file ownership match host values
* **Tests**
  * CI validation added across Docker build workflows to verify remapping behavior
  * New local test script to exercise remapping edge cases and re-entry prevention
* **Bug Fix / Behavior**
  * Startup no longer blocked by sync failures; sync errors now warn and startup proceeds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacificsky/devcontainer/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->