### PR TITLE
Float Go and prek versions in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,12 @@ RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.co
 USER root
 
 # Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:v0.3.4 /prek /usr/local/bin/prek
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
 
-# Layer 4: Install Go
-RUN GO_VERSION="1.26.0" && \
+# Layer 4: Install Go (latest stable, fetched from go.dev)
+RUN GO_VERSION=$(curl -fsSL "https://go.dev/VERSION?m=text" | head -n 1) && \
     ARCH=$(dpkg --print-architecture) && \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -xzC /usr/local && \
+    curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -xzC /usr/local && \
     echo 'export PATH=/usr/local/go/bin:$PATH' >> /etc/profile
 
 # Layer 5: Install Rust

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -48,7 +48,7 @@ RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.co
 USER root
 
 # Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:v0.3.4 /prek /usr/local/bin/prek
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
 
 # Layer 4: Install Node.js LTS
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \

--- a/Dockerfile.lite.tmux
+++ b/Dockerfile.lite.tmux
@@ -52,7 +52,7 @@ RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.co
 USER root
 
 # Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:v0.3.4 /prek /usr/local/bin/prek
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
 
 # Layer 4: Install Node.js LTS
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \


### PR DESCRIPTION
## Summary
- Go now fetches the current stable version from `https://go.dev/VERSION?m=text` instead of being pinned at `1.26.0`. This mirrors how Rust (rustup), Node (`setup_lts.x`), and the cloud CLIs already float on each daily build.
- `prek` switches from `v0.3.4` (17 releases stale; current is `v0.4.1`) to `:latest`. Verified that upstream's `:latest` and `v0.4.1` resolve to the same digest, so the floating tag is genuinely maintained.
- Applied to all three Dockerfiles (`Dockerfile`, `Dockerfile.lite`, `Dockerfile.lite.tmux`).

The existing `ARG CACHEBUST=${{ github.run_id }}` (passed by each daily workflow) sits above both layers, so daily builds will re-resolve and pick up new releases.

## Test plan
- [ ] PR builds (`docker-pr-build*.yml`) succeed for all three images
- [ ] After merge, next daily build completes and `go version` / `prek --version` inside the image report the latest releases
- [ ] Existing smoke test (`command -v claude && command -v codex && command -v gh`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to dynamically fetch and use the latest stable Go version instead of a fixed version
  * Updated pre-commit binary installation to use the latest release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacificsky/devcontainer/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->