### PR TITLE
Add keep-alive workflow to prevent scheduled workflow disabling

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,31 @@
+name: Keep-Alive Activity
+
+on:
+  schedule:
+    # 1st and 15th of every month — commits reset GitHub's 60-day
+    # inactivity timer that disables scheduled workflows
+    - cron: '0 0 1,15 * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Push via deploy key: deploy keys are the bypass actor in the
+      # main-protection ruleset (GITHUB_TOKEN cannot bypass it)
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.KEEPALIVE_DEPLOY_KEY }}
+
+      - name: Update timestamp
+        run: date > .github/keep-alive.txt
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/keep-alive.txt
+          git commit -m "chore: keep-alive workflow active"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,18 +39,21 @@ docker run --rm devcontainer:local /bin/bash -c "command -v claude && command -v
 
 ## CI/CD
 
-Six GitHub Actions workflows in `.github/workflows/`:
+Seven GitHub Actions workflows in `.github/workflows/`:
 
 | Workflow | Trigger | Image |
 |---|---|---|
 | `daily-docker-build.yml` | Daily 3AM PST + manual | full (`ghcr.io/<repo>`) |
 | `daily-docker-build-lite.yml` | Daily 3AM PST + manual | lite (`ghcr.io/<repo>-lite`) |
 | `daily-docker-build-lite-tmux.yml` | Daily 3AM PST + manual | lite+tmux (`ghcr.io/<repo>-lite-tmux`) |
-| `docker-pr-build.yml` | PR touching `Dockerfile` | full (build+test only) |
-| `docker-pr-build-lite.yml` | PR touching `Dockerfile.lite` | lite (build+test only) |
-| `docker-pr-build-lite-tmux.yml` | PR touching `Dockerfile.lite.tmux` | lite+tmux (build+test only) |
+| `docker-pr-build.yml` | Any PR | full (build+test only) |
+| `docker-pr-build-lite.yml` | Any PR | lite (build+test only) |
+| `docker-pr-build-lite-tmux.yml` | Any PR | lite+tmux (build+test only) |
+| `keep-alive.yml` | 1st & 15th monthly + manual | n/a (repo activity) |
 
 Daily builds: multi-arch (amd64/arm64) with digest-based merge, tagged `latest`, `daily-YYYY-MM-DD`, `YYYY-MM-DD`. Keeps last 7 versions. PR builds: single-arch validation with smoke tests.
+
+The keep-alive workflow commits a timestamp to `.github/keep-alive.txt` so the repo never hits GitHub's 60-day default-branch inactivity limit, which auto-disables scheduled workflows. It pushes directly to `main` over SSH using a write-access deploy key (`KEEPALIVE_DEPLOY_KEY` secret); deploy keys are the bypass actor in the `main-protection` ruleset, which otherwise requires PRs with passing `build-and-test-*` checks.
 
 ## Dockerfile Layer Strategy
 


### PR DESCRIPTION
GitHub disabled the three daily image-build workflows after 60 days without commits to `main` (only default-branch commits reset the inactivity timer — scheduled runs, tags, and PRs don't count).

## Changes

- **`.github/workflows/keep-alive.yml`**: runs on the 1st and 15th of each month (plus `workflow_dispatch`), writes a timestamp to `.github/keep-alive.txt`, and commits it to `main`. Twice-monthly leaves slack for a failed run inside the 60-day window. The workflow is self-sustaining: its own commits also reset its own timer.
- **`CLAUDE.md`**: documents the new workflow and corrects the PR-build trigger descriptions (they run on every PR — there is no `Dockerfile` path filter).

## Out-of-band config changes (already applied via `gh`)

- Replaced classic branch protection on `main` with the **`main-protection` ruleset** carrying the same rules (PRs required, `build-and-test-*` status checks, linear history, no force pushes/deletions) plus a **deploy-key bypass**. The `github-actions` app can't be a bypass actor on user-owned repos, so the workflow pushes over SSH with a repo-scoped write deploy key (`KEEPALIVE_DEPLOY_KEY` secret).
- Re-enabled the three `disabled_inactivity` daily build workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDo6qoN4A4yGWwufHAMWQG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated monthly activity update to help keep scheduled workflows active.
  * Added an option to trigger the activity update manually.

* **Documentation**
  * Updated CI/CD documentation to include the new workflow and its trigger conditions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->