### PR TITLE
Shrink images and split layers into stability tiers

### DIFF
--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -42,6 +42,13 @@ jobs:
         id: platform
         run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
+      # Toolchains and CLIs are refreshed weekly rather than daily, so six
+      # nights out of seven the build reuses those cached layers and only the
+      # AI CLI layers are rebuilt and pushed.
+      - name: Compute weekly toolchain refresh key
+        id: refresh
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
@@ -51,9 +58,13 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            CACHEBUST=${{ github.run_id }}
-          cache-from: type=gha,scope=lite-tmux-${{ steps.platform.outputs.slug }}
-          cache-to: type=gha,scope=lite-tmux-${{ steps.platform.outputs.slug }},mode=max
+            TOOLCHAIN_REFRESH=${{ steps.refresh.outputs.week }}
+            AI_CACHEBUST=${{ github.run_id }}
+          # Registry-backed cache: the GitHub Actions cache is capped at 10 GB
+          # per repo, which these images blow past across six mode=max scopes.
+          # Lives in its own package so the cleanup job below can't evict it.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:lite-tmux-${{ steps.platform.outputs.slug }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:lite-tmux-${{ steps.platform.outputs.slug }},mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Export digest
         run: |
@@ -134,35 +145,30 @@ jobs:
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
           echo "Testing daily build image: $IMAGE"
 
-          docker run --rm "$IMAGE" /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm "$IMAGE" /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            # Test Claude Code
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-              claude --version
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            for tool in claude codex gh uv prek man byobu; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            # Test OpenAI Codex
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-              codex --version
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            uv --version     || fail=1
 
-            # Test GitHub CLI
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-              gh --version
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
+            # Confirms the dpkg path-include + man-db diversion removal still work
+            man byobu >/dev/null 2>&1 || { echo "❌ man byobu failed"; fail=1; }
 
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         run: |

--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -86,6 +86,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    # The daily tags are gated on is_default_branch, so a workflow_dispatch on
+    # a feature branch produces only the branch-name tag. Publish whichever tag
+    # was actually created so test-image can find the image it just built.
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Download digests
@@ -142,7 +147,7 @@ jobs:
 
       - name: Test image functionality
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           echo "Testing daily build image: $IMAGE"
 
           docker run --rm "$IMAGE" /bin/bash -c '
@@ -172,7 +177,7 @@ jobs:
 
       - name: Test runtime UID/GID remap
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
             set -e
             echo "Inside container: uid=$(id -u) gid=$(id -g)"
@@ -189,7 +194,9 @@ jobs:
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest
-    if: success()
+    # Deleting published versions is irreversible; never do it from a
+    # workflow_dispatch on a feature branch.
+    if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     permissions:
       packages: write
 

--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -86,6 +86,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    # The daily tags are gated on is_default_branch, so a workflow_dispatch on
+    # a feature branch produces only the branch-name tag. Publish whichever tag
+    # was actually created so test-image can find the image it just built.
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Download digests
@@ -142,7 +147,7 @@ jobs:
 
       - name: Test image functionality
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           echo "Testing daily build image: $IMAGE"
 
           docker run --rm "$IMAGE" /bin/bash -c '
@@ -169,7 +174,7 @@ jobs:
 
       - name: Test runtime UID/GID remap
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
             set -e
             echo "Inside container: uid=$(id -u) gid=$(id -g)"
@@ -186,7 +191,9 @@ jobs:
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest
-    if: success()
+    # Deleting published versions is irreversible; never do it from a
+    # workflow_dispatch on a feature branch.
+    if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     permissions:
       packages: write
 

--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -42,6 +42,13 @@ jobs:
         id: platform
         run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
+      # Toolchains and CLIs are refreshed weekly rather than daily, so six
+      # nights out of seven the build reuses those cached layers and only the
+      # AI CLI layers are rebuilt and pushed.
+      - name: Compute weekly toolchain refresh key
+        id: refresh
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
@@ -51,9 +58,13 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            CACHEBUST=${{ github.run_id }}
-          cache-from: type=gha,scope=lite-${{ steps.platform.outputs.slug }}
-          cache-to: type=gha,scope=lite-${{ steps.platform.outputs.slug }},mode=max
+            TOOLCHAIN_REFRESH=${{ steps.refresh.outputs.week }}
+            AI_CACHEBUST=${{ github.run_id }}
+          # Registry-backed cache: the GitHub Actions cache is capped at 10 GB
+          # per repo, which these images blow past across six mode=max scopes.
+          # Lives in its own package so the cleanup job below can't evict it.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:lite-${{ steps.platform.outputs.slug }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:lite-${{ steps.platform.outputs.slug }},mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Export digest
         run: |
@@ -134,35 +145,27 @@ jobs:
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
           echo "Testing daily build image: $IMAGE"
 
-          docker run --rm "$IMAGE" /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm "$IMAGE" /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            # Test Claude Code
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-              claude --version
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            for tool in claude codex gh uv prek man; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            # Test OpenAI Codex
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-              codex --version
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            uv --version     || fail=1
 
-            # Test GitHub CLI
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-              gh --version
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
-
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         run: |

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -86,6 +86,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    # The daily tags are gated on is_default_branch, so a workflow_dispatch on
+    # a feature branch produces only the branch-name tag. Publish whichever tag
+    # was actually created so test-image can find the image it just built.
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Download digests
@@ -142,7 +147,7 @@ jobs:
 
       - name: Test image functionality
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           echo "Testing daily build image: $IMAGE"
 
           docker run --rm "$IMAGE" /bin/bash -c '
@@ -180,7 +185,7 @@ jobs:
 
       - name: Test runtime UID/GID remap
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}"
           docker run --rm -e HOST_UID=4242 -e HOST_GID=4243 "$IMAGE" /bin/bash -c '
             set -e
             echo "Inside container: uid=$(id -u) gid=$(id -g)"
@@ -197,7 +202,9 @@ jobs:
   cleanup-old-images:
     needs: [merge, test-image]
     runs-on: ubuntu-latest
-    if: success()
+    # Deleting published versions is irreversible; never do it from a
+    # workflow_dispatch on a feature branch.
+    if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     permissions:
       packages: write
 

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -42,6 +42,13 @@ jobs:
         id: platform
         run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
+      # Toolchains and cloud CLIs are refreshed weekly rather than daily, so
+      # six nights out of seven the build reuses those cached layers and only
+      # the AI CLI layers are rebuilt and pushed.
+      - name: Compute weekly toolchain refresh key
+        id: refresh
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
@@ -51,9 +58,13 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            CACHEBUST=${{ github.run_id }}
-          cache-from: type=gha,scope=${{ steps.platform.outputs.slug }}
-          cache-to: type=gha,scope=${{ steps.platform.outputs.slug }},mode=max
+            TOOLCHAIN_REFRESH=${{ steps.refresh.outputs.week }}
+            AI_CACHEBUST=${{ github.run_id }}
+          # Registry-backed cache: the GitHub Actions cache is capped at 10 GB
+          # per repo, which these images blow past across six mode=max scopes.
+          # Lives in its own package so the cleanup job below can't evict it.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:full-${{ steps.platform.outputs.slug }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-buildcache:full-${{ steps.platform.outputs.slug }},mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Export digest
         run: |
@@ -134,35 +145,38 @@ jobs:
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:daily-$(date +%Y-%m-%d)"
           echo "Testing daily build image: $IMAGE"
 
-          docker run --rm "$IMAGE" /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm "$IMAGE" /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            # Test Claude Code
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-              claude --version
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            # Every tool must resolve on PATH and actually execute. The version
+            # calls matter as much as the lookups: several of these are trimmed
+            # in the Dockerfile and a bad trim only shows up at runtime.
+            for tool in claude codex gh aws gcloud go rustc cargo uv prek man; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            # Test OpenAI Codex
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-              codex --version
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            aws --version    || fail=1
+            gcloud --version || fail=1
+            go version       || fail=1
+            rustc --version  || fail=1
+            cargo --version  || fail=1
+            uv --version     || fail=1
 
-            # Test GitHub CLI
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-              gh --version
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
+            # Confirms the dpkg path-include + man-db diversion removal still work
+            man byobu >/dev/null 2>&1 || { echo "❌ man byobu failed"; fail=1; }
 
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         run: |

--- a/.github/workflows/docker-pr-build-lite-tmux.yml
+++ b/.github/workflows/docker-pr-build-lite-tmux.yml
@@ -53,29 +53,30 @@ jobs:
       - name: Test image functionality
         if: steps.changes.outputs.dockerfile == 'true'
         run: |
-          docker run --rm devcontainer-lite-tmux:pr-test /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm devcontainer-lite-tmux:pr-test /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            for tool in claude codex gh uv prek man byobu; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            uv --version     || fail=1
 
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
+            # Confirms the dpkg path-include + man-db diversion removal still work
+            man byobu >/dev/null 2>&1 || { echo "❌ man byobu failed"; fail=1; }
 
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         if: steps.changes.outputs.dockerfile == 'true'

--- a/.github/workflows/docker-pr-build-lite.yml
+++ b/.github/workflows/docker-pr-build-lite.yml
@@ -53,29 +53,27 @@ jobs:
       - name: Test image functionality
         if: steps.changes.outputs.dockerfile == 'true'
         run: |
-          docker run --rm devcontainer-lite:pr-test /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm devcontainer-lite:pr-test /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            for tool in claude codex gh uv prek man; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            uv --version     || fail=1
 
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
-
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         if: steps.changes.outputs.dockerfile == 'true'

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -53,29 +53,38 @@ jobs:
       - name: Test image functionality
         if: steps.changes.outputs.dockerfile == 'true'
         run: |
-          docker run --rm devcontainer:pr-test /bin/bash -c "
-            echo 'Testing installations...'
+          docker run --rm devcontainer:pr-test /bin/bash -c '
+            echo "Testing installations..."
+            fail=0
 
-            if command -v claude >/dev/null 2>&1; then
-              echo '✅ Claude Code installed'
-            else
-              echo '❌ Claude Code missing' && exit 1
-            fi
+            # Every tool must resolve on PATH and actually execute. The version
+            # calls matter as much as the lookups: several of these are trimmed
+            # in the Dockerfile and a bad trim only shows up at runtime.
+            for tool in claude codex gh aws gcloud go rustc cargo uv prek man; do
+              if command -v "$tool" >/dev/null 2>&1; then
+                echo "✅ $tool -> $(command -v "$tool")"
+              else
+                echo "❌ $tool missing"
+                fail=1
+              fi
+            done
 
-            if command -v codex >/dev/null 2>&1; then
-              echo '✅ OpenAI Codex installed'
-            else
-              echo '❌ OpenAI Codex missing' && exit 1
-            fi
+            claude --version || fail=1
+            codex --version  || fail=1
+            gh --version     || fail=1
+            aws --version    || fail=1
+            gcloud --version || fail=1
+            go version       || fail=1
+            rustc --version  || fail=1
+            cargo --version  || fail=1
+            uv --version     || fail=1
 
-            if command -v gh >/dev/null 2>&1; then
-              echo '✅ GitHub CLI installed'
-            else
-              echo '❌ GitHub CLI missing' && exit 1
-            fi
+            # Confirms the dpkg path-include + man-db diversion removal still work
+            man byobu >/dev/null 2>&1 || { echo "❌ man byobu failed"; fail=1; }
 
-            echo 'All core tools are properly installed!'
-          "
+            [ "$fail" = 0 ] && echo "All core tools are properly installed!"
+            exit $fail
+          '
 
       - name: Test runtime UID/GID remap
         if: steps.changes.outputs.dockerfile == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,20 @@ Docker devcontainer images pre-loaded with AI coding agents (Claude Code, OpenAI
 
 ## Image Variants
 
-- **`Dockerfile`** (full): Dev tools + cloud CLIs (AWS, Azure, GCP) + GitHub CLI + byobu/tmux
+- **`Dockerfile`** (full): Dev tools + cloud CLIs (AWS, GCP) + GitHub CLI + byobu/tmux
 - **`Dockerfile.lite`**: Dev tools + GitHub CLI only, no cloud CLIs, no byobu/tmux
 - **`Dockerfile.lite.tmux`**: Same as lite but with byobu/tmux installed and auto-launched on login
 
 Both share the same base (`mcr.microsoft.com/devcontainers/base:ubuntu`). The full image includes Go, Rust, Node.js LTS, Python 3 + uv. The lite images include Node.js LTS, Python 3 + uv (no Go/Rust). They also diverge at the cloud CLI layer. Container user is `vscode`. The plain lite image is designed for use inside environments that already provide a terminal multiplexer (e.g. tmux on a remote VPS host).
+
+## Anything Installed Under /home/vscode Is At Risk
+
+The intended deployment mounts a named volume at `/home/vscode`, which **shadows whatever the image put there**. Anything a tool installs into the user's home directory is therefore invisible at runtime. Two consequences baked into the Dockerfiles:
+
+- **Rust lives at `/usr/local/{rustup,cargo}`**, not `~/.cargo` — set via `RUSTUP_HOME`/`CARGO_HOME` before `rustup-init` runs, with `chmod -R a+w` so `vscode` can `cargo install`. (An earlier version ran `rustup` as root and left ~1.2 GB in `/root/.cargo`, unreachable by `vscode` and off `PATH` entirely.)
+- **Claude Code cannot avoid `~/.local`**, so the build stages a copy at `/opt/claude-image/` and `scripts/entrypoint.sh` syncs it into the volume on container start. Install and stage happen in **one** `RUN` using `cp -al`, so the staged copy is hardlinked and costs ~0 bytes rather than duplicating ~80 MB in a second layer.
+
+Anything new that installs to the home directory needs the same treatment.
 
 ## Base Image Quirks
 
@@ -53,14 +62,31 @@ Seven GitHub Actions workflows in `.github/workflows/`:
 
 Daily builds: multi-arch (amd64/arm64) with digest-based merge, tagged `latest`, `daily-YYYY-MM-DD`, `YYYY-MM-DD`. Keeps last 7 versions. PR builds: single-arch validation with smoke tests.
 
+Daily builds use **registry-backed** build cache in a separate package, `ghcr.io/<repo>-buildcache`, tagged `<variant>-linux-<arch>`. Two reasons it is not the GitHub Actions cache: the GHA cache is capped at 10 GB per repo, which six `mode=max` scopes of these images exceed (causing constant LRU eviction), and a separate package keeps the cache out of reach of the `cleanup-old-images` job, which deletes all but the newest 7 versions of `devcontainer` regardless of tag. PR builds still use `type=gha` — they have no `packages: write` permission. GHCR requires `image-manifest=true,oci-mediatypes=true` on `cache-to` or it rejects the cache manifest.
+
 The keep-alive workflow commits a timestamp to `.github/keep-alive.txt` so the repo never hits GitHub's 60-day default-branch inactivity limit, which auto-disables scheduled workflows. It pushes directly to `main` over SSH using a write-access deploy key (`KEEPALIVE_DEPLOY_KEY` secret); deploy keys are the bypass actor in the `main-protection` ruleset, which otherwise requires PRs with passing `build-and-test-*` checks.
 
 ## Dockerfile Layer Strategy
 
-Layers are ordered by stability (most stable first) to maximize cache hits.
+All three Dockerfiles are split into three tiers by how often their contents actually change. Each tier is gated by its own `ARG`, and the daily workflows feed those args at different cadences, so a nightly rebuild only produces new layers for the things that genuinely shipped that day.
 
-**Full image**: System packages → uv → Go → Rust → Node.js LTS → Cloud CLIs + GitHub CLI → Shell config → AI tools → ENV/PATH
+| Tier | Gate | Cadence | Contents |
+|---|---|---|---|
+| 1 | none | on file change | UID/GID remap, apt packages, `chsh` |
+| 2 | `TOOLCHAIN_REFRESH` | weekly (`date -u +%G-%V`) | Go, Rust, Node.js, cloud CLIs, GitHub CLI, `uv`, `prek` |
+| 3 | `AI_CACHEBUST` | daily (`github.run_id`) | Claude Code, OpenAI Codex |
 
-**Lite image**: System packages → uv → Node.js LTS → GitHub CLI → Shell config → AI tools → ENV/PATH
+**Full image**: system packages → *[weekly]* Go → Rust → Node.js LTS → cloud CLIs + GitHub CLI → uv + prek → *[daily]* AI tools → shell config → ENV/PATH
 
-**Lite+Tmux image**: Same as lite but with byobu (tmux) in the system packages layer and auto-launch in shell config
+**Lite image**: system packages → *[weekly]* Node.js LTS → GitHub CLI → uv + prek → *[daily]* AI tools → shell config → ENV/PATH
+
+**Lite+Tmux image**: same as lite, plus byobu in the system packages layer and auto-launch in shell config
+
+Ordering rules worth preserving when editing:
+
+- **Shell config (`.zshrc`, `.p10k.zsh`, powerlevel10k) goes last**, below the AI tools. Tweaking zsh config then rebuilds ~1 MB instead of invalidating ~350 MB of AI CLI layers.
+- **`uv` and `prek` sit at the bottom of tier 2.** They are `COPY --from=<image>:latest`, so a new upstream digest invalidates everything below them; last in the tier means that costs two tiny layers, not every toolchain.
+- **Each `RUN` cleans up after itself in the same `RUN`.** A later `rm -rf /var/lib/apt/lists/*` cannot reclaim space an earlier layer already committed — it just adds a whiteout. This is why the Node.js layer drops its own apt lists even though a later layer does the same.
+- Whole-line `#` comments are stripped by Docker before the shell sees them, which is why they can appear mid-`&&`-chain inside a `RUN`.
+
+Several components are trimmed after install: `go/test`, gcloud's `anthoscli` / `.install/.backup` / bundled interpreter (with `CLOUDSDK_PYTHON` pinned to the system one), awscli's bundled help `examples`, `__pycache__` trees, and the npm tarball cache. Rust uses `--profile minimal` plus explicit `clippy`/`rustfmt` to skip `rust-docs`. The PR and daily smoke tests run `--version` on every trimmed tool — a bad trim only surfaces at runtime, so keep those assertions in sync when adding or removing a tool.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,23 @@ RUN if getent group 20 > /dev/null 2>&1; then \
     usermod -u 501 -g 20 vscode && \
     chown -R 501:20 /home/vscode
 
-# Layer 1: Base system dependencies and utilities (most stable)
+# ---------------------------------------------------------------------------
+# Tier 1 — stable. Only rebuilt when this file changes.
+# ---------------------------------------------------------------------------
+
+# Base system dependencies and utilities
 # Re-include byobu docs/man (base image minimized via /etc/dpkg/dpkg.cfg.d/excludes)
 # Filename zz- ensures this is processed AFTER excludes so includes win
 # Remove man stub diversion so man-db can install the real man binary
+# --no-install-recommends keeps the layer lean; less is listed explicitly
+# because man-db only Recommends a pager and man is unusable without one.
 RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man1/byobu*\n' > /etc/dpkg/dpkg.cfg.d/zz-byobu && \
     rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && \
     apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         curl wget unzip \
         jq yq \
-        vim nano \
+        vim nano less \
         make \
         build-essential \
         python3 python3-pip \
@@ -35,70 +41,115 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
         tcpdump \
         telnet \
         nmap && \
+    chsh -s /usr/bin/zsh vscode && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 2: Install uv (modern Python package manager)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# ---------------------------------------------------------------------------
+# Tier 2 — language toolchains and cloud CLIs. These float to whatever is
+# current at build time, but they rarely change day to day, so the daily
+# workflow only busts them once a week (TOOLCHAIN_REFRESH carries an ISO week
+# number). Six nights out of seven these layers come straight from cache.
+# ---------------------------------------------------------------------------
+ARG TOOLCHAIN_REFRESH
 
-# Cache-bust from here down so daily builds pick up new versions of
-# everything installed via script (Homebrew, Go, Rust, Node, CLIs, AI tools)
-ARG CACHEBUST
-
-# Layer 3: Install Homebrew
-USER vscode
-RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-USER root
-
-# Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
-
-# Layer 4: Install Go (latest stable, fetched from go.dev)
+# Layer 1: Install Go (latest stable, fetched from go.dev)
+# go/test is the compiler's own test corpus and is dead weight in an image.
 RUN GO_VERSION=$(curl -fsSL "https://go.dev/VERSION?m=text" | head -n 1) && \
     ARCH=$(dpkg --print-architecture) && \
     curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -xzC /usr/local && \
+    rm -rf /usr/local/go/test && \
     echo 'export PATH=/usr/local/go/bin:$PATH' >> /etc/profile
 
-# Layer 5: Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    echo 'source ~/.cargo/env' >> /etc/profile
+# Layer 2: Install Rust
+# Installed under /usr/local rather than rustup's default ~/.cargo: a named
+# volume mounted at /home/vscode shadows the image layer, which would hide the
+# toolchain entirely at runtime. The minimal profile drops rust-docs (several
+# hundred MB of HTML); clippy and rustfmt are added back explicitly.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --no-modify-path --profile minimal -c clippy -c rustfmt && \
+    chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME" && \
+    echo 'export PATH=/usr/local/cargo/bin:$PATH' >> /etc/profile
 
-# Layer 6: Install Node.js LTS
+# Layer 3: Install Node.js LTS
+# nodesource's setup script runs apt-get update, so this layer has to drop the
+# package lists itself — a later RUN cannot reclaim space from an earlier one.
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Layer 7: Install cloud CLIs (moderately stable)
+# Layer 4: Install cloud CLIs (AWS, Google Cloud) and GitHub CLI
+# Pointing gcloud at the system interpreter lets the bundled one go, if the
+# package ships one at all.
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then \
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
-    elif [ "$ARCH" = "arm64" ]; then \
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
-    else \
-        echo "Unsupported architecture: $ARCH"; exit 1; \
-    fi && \
-    unzip awscliv2.zip && \
+    case "$ARCH" in \
+        amd64) AWS_ARCH=x86_64 ;; \
+        arm64) AWS_ARCH=aarch64 ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o awscliv2.zip && \
+    unzip -q awscliv2.zip && \
     ./aws/install && \
     rm -rf aws awscliv2.zip && \
-    # Install Azure CLI
-    curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     # Install Google Cloud CLI
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-cli && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     # Install GitHub CLI
     mkdir -p -m 755 /etc/apt/keyrings && \
-    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
+    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg > /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh && \
+    echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends google-cloud-cli gh && \
+    # Trim: awscli's bundled help examples, gcloud's Anthos binary (~100 MB),
+    # the component manager's rollback copies, and the bundled interpreter.
+    find /usr/local/aws-cli -type d -name examples -prune -exec rm -rf {} + && \
+    rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli \
+           /usr/lib/google-cloud-sdk/.install/.backup \
+           /usr/lib/google-cloud-sdk/platform/bundledpythonunix && \
+    find /usr/local/aws-cli /usr/lib/google-cloud-sdk -type d -name __pycache__ -prune -exec rm -rf {} + && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 8: Shell configuration
-RUN chsh -s /usr/bin/zsh vscode
+# Layer 5: single-binary tools tracked by upstream :latest tags. Kept at the
+# bottom of this tier so a new upstream digest invalidates only these two tiny
+# layers rather than every toolchain above them.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
+
+# ---------------------------------------------------------------------------
+# Tier 3 — AI CLIs. These genuinely ship most days, so they carry the daily
+# cache-bust and sit last, where rebuilding them costs the least.
+# ---------------------------------------------------------------------------
+ARG AI_CACHEBUST
+
 USER vscode
+
+# Install Claude Code, and stage a copy outside /home/vscode so it survives a
+# volume mount. Install and stage share one layer and the staged copy is
+# hardlinked, so the second copy costs ~0 bytes instead of duplicating ~80 MB.
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
+    sudo mkdir -p /opt/claude-image/versions && \
+    sudo cp -al /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" \
+                /opt/claude-image/versions/ && \
+    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
+
+# Install OpenAI Codex, dropping the npm tarball cache it leaves behind
+RUN sudo npm install -g @openai/codex && \
+    sudo npm cache clean --force && \
+    npm cache clean --force
+
+# ---------------------------------------------------------------------------
+# Shell configuration last: editing .zshrc or .p10k.zsh then rebuilds ~1 MB
+# instead of invalidating the AI tool layers above it.
+# ---------------------------------------------------------------------------
 COPY --chown=vscode:vscode config/.zshrc /home/vscode/.zshrc
 COPY --chown=vscode:vscode config/.p10k.zsh /home/vscode/.p10k.zsh
 RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
@@ -107,21 +158,8 @@ RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
     printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.zprofile && \
     printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.profile
 
-# Layer 9: AI CLI tools (most volatile - frequent releases)
-# Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Stage Claude installation outside /home/vscode so it survives volume mounts
-RUN CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
-    sudo mkdir -p /opt/claude-image/versions && \
-    sudo cp -a /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" /opt/claude-image/versions/ && \
-    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
-
-# Install OpenAI Codex
-RUN sudo npm install -g @openai/codex
-
-# Layer 10: Final environment setup
-ENV PATH="/home/vscode/.local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/go/bin:/home/vscode/.cargo/bin:${PATH}"
+# Final environment setup
+ENV PATH="/home/vscode/.local/bin:/usr/local/go/bin:/usr/local/cargo/bin:${PATH}"
 ENV SHELL=/usr/bin/zsh
 ENV DISABLE_AUTOUPDATER=true
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,4 +1,4 @@
-# Lite variant: dev tools + AI agents, no cloud CLIs (AWS/Azure/GCP)
+# Lite variant: dev tools + AI agents, no cloud CLIs (AWS/GCP)
 # For the full image with cloud CLIs, use Dockerfile
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
@@ -11,14 +11,20 @@ RUN if getent group 20 > /dev/null 2>&1; then \
     usermod -u 501 -g 20 vscode && \
     chown -R 501:20 /home/vscode
 
-# Layer 1: Base system dependencies and utilities (most stable)
+# ---------------------------------------------------------------------------
+# Tier 1 — stable. Only rebuilt when this file changes.
+# ---------------------------------------------------------------------------
+
+# Base system dependencies and utilities
 # Remove man stub diversion so man-db can install the real man binary
+# --no-install-recommends keeps the layer lean; less is listed explicitly
+# because man-db only Recommends a pager and man is unusable without one.
 RUN rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && \
     apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         curl wget unzip \
         jq yq \
-        vim nano \
+        vim nano less \
         make \
         build-essential \
         python3 python3-pip \
@@ -31,61 +37,76 @@ RUN rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && 
         tcpdump \
         telnet \
         nmap && \
+    chsh -s /usr/bin/zsh vscode && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 2: Install uv (modern Python package manager)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# ---------------------------------------------------------------------------
+# Tier 2 — toolchains and CLIs. These float to whatever is current at build
+# time, but they rarely change day to day, so the daily workflow only busts
+# them once a week (TOOLCHAIN_REFRESH carries an ISO week number). Six nights
+# out of seven these layers come straight from cache.
+# ---------------------------------------------------------------------------
+ARG TOOLCHAIN_REFRESH
 
-# Cache-bust from here down so daily builds pick up new versions of
-# everything installed via script (Homebrew, Node, GitHub CLI, AI tools)
-ARG CACHEBUST
-
-# Layer 3: Install Homebrew
-USER vscode
-RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-USER root
-
-# Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
-
-# Layer 4: Install Node.js LTS
+# Layer 1: Install Node.js LTS
+# nodesource's setup script runs apt-get update, so this layer has to drop the
+# package lists itself — a later RUN cannot reclaim space from an earlier one.
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
-    apt-get install -y nodejs
-
-# Layer 5: Install GitHub CLI
-RUN mkdir -p -m 755 /etc/apt/keyrings && \
-    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
-    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh && \
+    apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 6: Shell configuration
-RUN chsh -s /usr/bin/zsh vscode
+# Layer 2: Install GitHub CLI
+RUN mkdir -p -m 755 /etc/apt/keyrings && \
+    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg > /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Layer 3: single-binary tools tracked by upstream :latest tags. Kept at the
+# bottom of this tier so a new upstream digest invalidates only these two tiny
+# layers rather than every toolchain above them.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
+
+# ---------------------------------------------------------------------------
+# Tier 3 — AI CLIs. These genuinely ship most days, so they carry the daily
+# cache-bust and sit last, where rebuilding them costs the least.
+# ---------------------------------------------------------------------------
+ARG AI_CACHEBUST
+
 USER vscode
+
+# Install Claude Code, and stage a copy outside /home/vscode so it survives a
+# volume mount. Install and stage share one layer and the staged copy is
+# hardlinked, so the second copy costs ~0 bytes instead of duplicating ~80 MB.
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
+    sudo mkdir -p /opt/claude-image/versions && \
+    sudo cp -al /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" \
+                /opt/claude-image/versions/ && \
+    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
+
+# Install OpenAI Codex, dropping the npm tarball cache it leaves behind
+RUN sudo npm install -g @openai/codex && \
+    sudo npm cache clean --force && \
+    npm cache clean --force
+
+# ---------------------------------------------------------------------------
+# Shell configuration last: editing .zshrc or .p10k.zsh then rebuilds ~1 MB
+# instead of invalidating the AI tool layers above it.
+# ---------------------------------------------------------------------------
 COPY --chown=vscode:vscode config/.zshrc /home/vscode/.zshrc
 COPY --chown=vscode:vscode config/.p10k.zsh /home/vscode/.p10k.zsh
 RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
     ${ZSH_CUSTOM:-/home/vscode/.oh-my-zsh/custom}/themes/powerlevel10k
 
-# Layer 7: AI CLI tools (most volatile - frequent releases)
-# Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Stage Claude installation outside /home/vscode so it survives volume mounts
-RUN CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
-    sudo mkdir -p /opt/claude-image/versions && \
-    sudo cp -a /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" /opt/claude-image/versions/ && \
-    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
-
-# Install OpenAI Codex
-RUN sudo npm install -g @openai/codex
-
-# Layer 8: Final environment setup
-ENV PATH="/home/vscode/.local/bin:/home/linuxbrew/.linuxbrew/bin:${PATH}"
+# Final environment setup
+ENV PATH="/home/vscode/.local/bin:${PATH}"
 ENV SHELL=/usr/bin/zsh
 ENV DISABLE_AUTOUPDATER=true
 

--- a/Dockerfile.lite.tmux
+++ b/Dockerfile.lite.tmux
@@ -1,4 +1,4 @@
-# Lite variant: dev tools + AI agents, no cloud CLIs (AWS/Azure/GCP)
+# Lite+tmux variant: dev tools + AI agents + byobu, no cloud CLIs (AWS/GCP)
 # For the full image with cloud CLIs, use Dockerfile
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
@@ -11,17 +11,23 @@ RUN if getent group 20 > /dev/null 2>&1; then \
     usermod -u 501 -g 20 vscode && \
     chown -R 501:20 /home/vscode
 
-# Layer 1: Base system dependencies and utilities (most stable)
+# ---------------------------------------------------------------------------
+# Tier 1 — stable. Only rebuilt when this file changes.
+# ---------------------------------------------------------------------------
+
+# Base system dependencies and utilities
 # Re-include byobu docs/man (base image minimized via /etc/dpkg/dpkg.cfg.d/excludes)
 # Filename zz- ensures this is processed AFTER excludes so includes win
 # Remove man stub diversion so man-db can install the real man binary
+# --no-install-recommends keeps the layer lean; less is listed explicitly
+# because man-db only Recommends a pager and man is unusable without one.
 RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man1/byobu*\n' > /etc/dpkg/dpkg.cfg.d/zz-byobu && \
     rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man && \
     apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         curl wget unzip \
         jq yq \
-        vim nano \
+        vim nano less \
         make \
         build-essential \
         python3 python3-pip \
@@ -35,41 +41,69 @@ RUN printf 'path-include /usr/share/doc/byobu/*\npath-include /usr/share/man/man
         tcpdump \
         telnet \
         nmap && \
+    chsh -s /usr/bin/zsh vscode && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 2: Install uv (modern Python package manager)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# ---------------------------------------------------------------------------
+# Tier 2 — toolchains and CLIs. These float to whatever is current at build
+# time, but they rarely change day to day, so the daily workflow only busts
+# them once a week (TOOLCHAIN_REFRESH carries an ISO week number). Six nights
+# out of seven these layers come straight from cache.
+# ---------------------------------------------------------------------------
+ARG TOOLCHAIN_REFRESH
 
-# Cache-bust from here down so daily builds pick up new versions of
-# everything installed via script (Homebrew, Node, GitHub CLI, AI tools)
-ARG CACHEBUST
-
-# Layer 3: Install Homebrew
-USER vscode
-RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-USER root
-
-# Layer 3.1: install prek (pre-commit implementation in Rust)
-COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
-
-# Layer 4: Install Node.js LTS
+# Layer 1: Install Node.js LTS
+# nodesource's setup script runs apt-get update, so this layer has to drop the
+# package lists itself — a later RUN cannot reclaim space from an earlier one.
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
-    apt-get install -y nodejs
-
-# Layer 5: Install GitHub CLI
-RUN mkdir -p -m 755 /etc/apt/keyrings && \
-    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
-    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh && \
+    apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Layer 6: Shell configuration
-RUN chsh -s /usr/bin/zsh vscode
+# Layer 2: Install GitHub CLI
+RUN mkdir -p -m 755 /etc/apt/keyrings && \
+    wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg > /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Layer 3: single-binary tools tracked by upstream :latest tags. Kept at the
+# bottom of this tier so a new upstream digest invalidates only these two tiny
+# layers rather than every toolchain above them.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/j178/prek:latest /prek /usr/local/bin/prek
+
+# ---------------------------------------------------------------------------
+# Tier 3 — AI CLIs. These genuinely ship most days, so they carry the daily
+# cache-bust and sit last, where rebuilding them costs the least.
+# ---------------------------------------------------------------------------
+ARG AI_CACHEBUST
+
 USER vscode
+
+# Install Claude Code, and stage a copy outside /home/vscode so it survives a
+# volume mount. Install and stage share one layer and the staged copy is
+# hardlinked, so the second copy costs ~0 bytes instead of duplicating ~80 MB.
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
+    sudo mkdir -p /opt/claude-image/versions && \
+    sudo cp -al /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" \
+                /opt/claude-image/versions/ && \
+    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
+
+# Install OpenAI Codex, dropping the npm tarball cache it leaves behind
+RUN sudo npm install -g @openai/codex && \
+    sudo npm cache clean --force && \
+    npm cache clean --force
+
+# ---------------------------------------------------------------------------
+# Shell configuration last: editing .zshrc or .p10k.zsh then rebuilds ~1 MB
+# instead of invalidating the AI tool layers above it.
+# ---------------------------------------------------------------------------
 COPY --chown=vscode:vscode config/.zshrc /home/vscode/.zshrc
 COPY --chown=vscode:vscode config/.p10k.zsh /home/vscode/.p10k.zsh
 RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
@@ -78,21 +112,8 @@ RUN git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
     printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.zprofile && \
     printf '_byobu_sourced=1 . /usr/bin/byobu-launch 2>/dev/null || true\n' >> ~/.profile
 
-# Layer 7: AI CLI tools (most volatile - frequent releases)
-# Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Stage Claude installation outside /home/vscode so it survives volume mounts
-RUN CLAUDE_VERSION=$(basename "$(readlink /home/vscode/.local/bin/claude)") && \
-    sudo mkdir -p /opt/claude-image/versions && \
-    sudo cp -a /home/vscode/.local/share/claude/versions/"${CLAUDE_VERSION}" /opt/claude-image/versions/ && \
-    echo "${CLAUDE_VERSION}" | sudo tee /opt/claude-image/version > /dev/null
-
-# Install OpenAI Codex
-RUN sudo npm install -g @openai/codex
-
-# Layer 8: Final environment setup
-ENV PATH="/home/vscode/.local/bin:/home/linuxbrew/.linuxbrew/bin:${PATH}"
+# Final environment setup
+ENV PATH="/home/vscode/.local/bin:${PATH}"
 ENV SHELL=/usr/bin/zsh
 ENV DISABLE_AUTOUPDATER=true
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -47,8 +47,7 @@ remap_and_reexec() {
             fi
             groupmod -g "$HOST_GID" vscode
             usermod  -u "$HOST_UID" vscode
-            # Chown anything under /home owned by the old UID/GID. Covers
-            # /home/vscode and /home/linuxbrew (full image only).
+            # Chown anything under /home owned by the old UID/GID.
             find /home -uid "$CURRENT_UID" -exec chown -h "$HOST_UID" {} + || true
             find /home -gid "$CURRENT_GID" -exec chgrp -h "$HOST_GID" {} + || true
             # Drop privileges to the freshly-remapped vscode and re-enter the


### PR DESCRIPTION
## Why

Measured from the published GHCR manifest (amd64, compressed — what users actually download):

| | |
|---|---:|
| `devcontainer:latest` | **1795 MB** |
| `devcontainer-lite:latest` | **1098 MB** |
| `devcontainer-lite-tmux:latest` | **1100 MB** |

Mapping every layer back to its Dockerfile command turned up three things worth fixing:

**Rust was unreachable.** `rustup` runs at `Dockerfile:64` while `USER root` is in effect, so the toolchain landed in `/root/.cargo` — but `ENV PATH` advertised `/home/vscode/.cargo/bin`, and `/root` is mode 0700. I confirmed this by streaming the layer and listing it: it contains `root/.cargo/` and `root/.rustup/`. 290 MB compressed (~1.2 GB on disk) that the `vscode` user could not use.

**Homebrew had an empty Cellar.** 162 MB of `Homebrew/Library` plus a `.git` repo and the formula API cache. `Cellar/` is an empty directory, and no Dockerfile anywhere runs `brew install`.

**Claude Code was stored twice.** `Dockerfile:112` installs it and `Dockerfile:115-118` copies it to `/opt/claude-image` in a *separate* `RUN`, so the copy lands in its own 83 MB layer.

## What changed

**Size**
- Rust installs to `/usr/local/{rustup,cargo}` with `--profile minimal -c clippy -c rustfmt`. `/usr/local` rather than the vscode home directory on purpose — a named volume at `/home/vscode` would have hidden it just as effectively as `/root` did.
- Homebrew removed, along with `/home/linuxbrew/.linuxbrew/bin` from `PATH`.
- Azure CLI removed. gcloud trimmed (`anthoscli`, `.install/.backup`, bundled interpreter with `CLOUDSDK_PYTHON` pinned to the system one); awscli's bundled help `examples` and `__pycache__` trees dropped.
- Claude install and staging merged into one `RUN` using `cp -al`, so the staged copy is hardlinked.
- `--no-install-recommends` throughout, with `less` added explicitly since man-db only *Recommends* a pager.
- The Node layer drops its own apt lists. A later `rm -rf` cannot reclaim space an earlier layer committed — it just adds a whiteout. Same reason the npm tarball cache is cleaned in the Codex layer.

**Layer caching**

`ARG CACHEBUST` sat above everything, so each nightly build emitted ~1.48 GB of new layers even when no toolchain had changed — with knock-on cost in GHCR storage (7 daily versions sharing almost no layers) and in every `docker pull latest`.

Split into two tiers:

| Tier | Gate | Cadence | Contents |
|---|---|---|---|
| 1 | none | on file change | UID/GID remap, apt packages, `chsh` |
| 2 | `TOOLCHAIN_REFRESH` | weekly (`date -u +%G-%V`) | Go, Rust, Node, cloud CLIs, gh, uv, prek |
| 3 | `AI_CACHEBUST` | daily (`github.run_id`) | Claude Code, Codex |

Shell config moves below the AI tools, so editing `.zshrc` rebuilds ~1 MB instead of invalidating ~350 MB. `uv`/`prek` move to the bottom of tier 2, so a new upstream `:latest` digest invalidates two tiny layers instead of every toolchain above them.

Daily builds also move from the GitHub Actions cache to a registry cache. The GHA cache is capped at 10 GB per repo, which six `mode=max` scopes of these images exceed — it was thrashing regardless of the cachebust. It lives in a **separate** `-buildcache` package because `cleanup-old-images` deletes all but 7 versions of the `devcontainer` package with `delete-only-untagged-versions: false`, which would evict a cache tag in the same package. PR builds stay on `type=gha` (no `packages: write`).

**Trade-off:** apt-installed `nodejs` and `gh` security updates now lag up to 7 days. Easy to move either back to the daily tier if that's not acceptable.

## Measured results

Both columns measured the same day off the pushed manifests, so the drifting upstream base image cancels out.

| Image | before | after | delta |
|---|---:|---:|---:|
| `devcontainer` amd64 | 1800 MB | **1099 MB** | −701 (−39%) |
| `devcontainer` arm64 | 1700 MB | **1040 MB** | −660 (−39%) |
| `devcontainer-lite` amd64 | 1103 MB | **690 MB** | −413 (−37%) |
| `devcontainer-lite` arm64 | 1076 MB | **670 MB** | −406 (−38%) |
| `devcontainer-lite-tmux` amd64 | 1106 MB | **692 MB** | −414 (−37%) |
| `devcontainer-lite-tmux` arm64 | 1078 MB | **672 MB** | −406 (−38%) |

Where the 704 MB went, layer by layer on the full amd64 image:

| Layer | before | after | delta |
|---|---:|---:|---:|
| Homebrew | 161.5 MB | — | −161.5 |
| Cloud CLIs | 354.4 MB | 139.3 MB | −215.1 |
| Codex (npm cache) | 260.9 MB | 132.4 MB | −128.5 |
| Claude staging copy | 82.5 MB | — | −82.5 |
| Rust | 290.4 MB | 218.2 MB | −72.2 |
| Node.js | 85.8 MB | 55.9 MB | −29.9 |
| apt base | 61.2 MB | 51.8 MB | −9.4 |
| Go | 64.1 MB | 63.2 MB | −0.9 |

Two of these were flagged as uncertain in the original write-up and both resolved favourably:

- **The npm cache was half the Codex layer.** `npm cache clean --force` recovered 128.5 MB, not the ~100 MB estimated.
- **The hardlink worked.** BuildKit does emit `TypeLink` for same-layer hardlinks, so the staged Claude copy collapsed from a separate 82.5 MB layer to zero. There is now exactly one Claude layer.

Daily layer churn drops from ~1.48 GB to **~216 MB** (Claude 83 + Codex 132 + config 0.7) on the six nights a week the toolchain tier is cached.

## Testing

Verified locally: all seven workflow YAMLs parse, every embedded test script passes `bash -n`, every Dockerfile `RUN` body passes `bash -n`, and `scripts/test_entrypoint.sh` passes 6/6.

**Not built locally — there is no Docker in the authoring environment.** The measured column comes from the published manifest; the projected column is inference. So the smoke tests were extended to assert `--version` on every trimmed tool plus `man byobu` — a bad trim only surfaces at runtime.

Two checks to watch on this PR's CI:
- `gcloud --version` — proves removing the bundled interpreter is safe
- `man byobu` — proves `--no-install-recommends` didn't break the dpkg path-include / man-db diversion machinery

The hardlink saving depends on BuildKit emitting `TypeLink` for same-layer hardlinks. If it doesn't, the 83 MB simply isn't saved; nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhYSsmY247P8wD5b3uTFJW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added and reorganized development tools across standard, lite, and tmux-enabled images, including Rust, Go, Node.js, GitHub CLI, `uv`, and `prek`.
  * Added support for updated AI command-line tools, including Claude Code and OpenAI Codex.
  * Improved image caching and scheduled toolchain refreshes for more reliable builds.

* **Bug Fixes**
  * Expanded image validation to check installed tools, version commands, and `man byobu` functionality.
  * Improved installation cleanup and reduced unnecessary image contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
