### PR TITLE
Upgrade GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/daily-docker-build-lite-tmux.yml
+++ b/.github/workflows/daily-docker-build-lite-tmux.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.lite.tmux
@@ -73,7 +73,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-lite-tmux-${{ steps.platform.outputs.slug }}
           path: /tmp/digests/*
@@ -94,17 +94,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-lite-tmux-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/daily-docker-build-lite.yml
+++ b/.github/workflows/daily-docker-build-lite.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.lite
@@ -73,7 +73,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-lite-${{ steps.platform.outputs.slug }}
           path: /tmp/digests/*
@@ -94,17 +94,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-lite-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/daily-docker-build.yml
+++ b/.github/workflows/daily-docker-build.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -73,7 +73,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ steps.platform.outputs.slug }}
           path: /tmp/digests/*
@@ -94,17 +94,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker-pr-build-lite-tmux.yml
+++ b/.github/workflows/docker-pr-build-lite-tmux.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Test entrypoint gating logic
         if: steps.changes.outputs.dockerfile == 'true'
@@ -54,11 +54,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.lite.tmux

--- a/.github/workflows/docker-pr-build-lite.yml
+++ b/.github/workflows/docker-pr-build-lite.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Test entrypoint gating logic
         if: steps.changes.outputs.dockerfile == 'true'
@@ -54,11 +54,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.lite

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Test entrypoint gating logic
         if: steps.changes.outputs.dockerfile == 'true'
@@ -54,11 +54,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
         if: steps.changes.outputs.dockerfile == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Push via deploy key: deploy keys are the bypass actor in the
       # main-protection ruleset (GITHUB_TOKEN cannot bypass it)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.KEEPALIVE_DEPLOY_KEY }}
 


### PR DESCRIPTION
## Summary

Daily builds emit: *"Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24."* This bumps every action to its current major:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `docker/build-push-action` | v5 | **v7** |
| `docker/login-action` | v3 | **v4** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `dorny/paths-filter` | v3 | **v4** |
| `actions/delete-package-versions` | v5 | v5 (already current) |

## Breaking-change review

Release notes checked at every major boundary. All are Node 24 + ESM runtime bumps for our usage. The real breaking changes land elsewhere:

- `download-artifact` v5's path change affects **by-ID** downloads only — the digest merge flow downloads by `pattern` + `merge-multiple`, unchanged since v4.
- `download-artifact` v8's digest-mismatch-errors default is a desirable hardening.
- `setup-buildx` v4 removed deprecated inputs — we pass none.
- `build-push` v7 removed `DOCKER_BUILD_NO_SUMMARY`/`DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — we set neither.
- `checkout` v6 moved persisted credentials to a separate file; keep-alive's `ssh-key` flow is unaffected (verified input still supported).

Minimum runner version for Node 24 actions is 2.327.1 — GitHub-hosted runners are well past it.

## Testing

PR builds exercise checkout/buildx/build-push/paths-filter at the new majors directly. The daily-only actions (login, metadata, upload/download-artifact) get verified by a manual dispatch of the lite daily build after merge, which should also come back warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BizqL59aDfL8TarUhtRcw7